### PR TITLE
Change softWindowInputMode for easy access to buttons

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             android:name=".ui.MainActivity"
             android:parentActivityName=".ui.LoginActivity"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustResize" />
 
         <activity
             android:name=".ui.SplashActivity"


### PR DESCRIPTION
Constraint layout has this default adjustment when keyboard appears when it has double chains to order views. Since the fragments have been changed to constraint layouts this fixes the issue by changing softwindowinputmode